### PR TITLE
Fix up julia_eval

### DIFF
--- a/R/rjulia.R
+++ b/R/rjulia.R
@@ -74,8 +74,8 @@ julia_eval <- function(expression) {
   #Otherwise, evaluate the expression and return the results of that evaluation. If it's appropriate
   #to provide it to the user as a vector, do so - otherwise provide it raw.
   eval_result <- .Call("jl_eval", expression, PACKAGE="rjulia")
-  if((length(dim(y)) == 1)||(length(y) == 1)) {
-    return (as.vector(y))
+  if((length(dim(eval_result)) == 1)||(length(eval_result) == 1)) {
+    return (as.vector(eval_result))
   }
 }
 


### PR DESCRIPTION
Specifically:
1. Remove Julia_is_running. It consistents entirely of a single call to an underlying C function; given the cost of function evaluation in R, and the purpose of functions, that doesn't qualify. The call is just inserted directly into the control flow in julia_eval (since that's the only place it's used);
2. Standardise code formatting;
3. Tweak error message;
4. Rename "y" to eval_results: variable names should explain what the variable contains.
