### PR TITLE
Array creation

### DIFF
--- a/src/R_Julia.c
+++ b/src/R_Julia.c
@@ -109,8 +109,9 @@ static jl_value_t *R_Julia_MD(SEXP Var, const char *VarName)
     {
       ret = CreateArray(jl_bool_type, jl_nfields(dims), dims);
       char *retData = (char *)jl_array_data(ret);
-      for (size_t i = 0; i < jl_array_len(ret); i++)
-        retData[i] = LOGICAL(Var)[i];
+      int *var_p = LOGICAL(Var);
+      for (size_t i = 0; i < jl_array_len(ret); i++) // Can not be memcpy because we want the implicit cast
+        retData[i] = var_p[i];
       jl_set_global(jl_main_module, jl_symbol(VarName), (jl_value_t *)ret);
       break;
     };
@@ -118,8 +119,7 @@ static jl_value_t *R_Julia_MD(SEXP Var, const char *VarName)
     {
       ret = CreateArray(jl_int32_type, jl_nfields(dims), dims);
       int *retData = (int *)jl_array_data(ret);
-      for (size_t i = 0; i < jl_array_len(ret); i++)
-        retData[i] = INTEGER(Var)[i];
+      memcpy(retData, REAL(Var), jl_array_len(ret) * sizeof(retData));
       jl_set_global(jl_main_module, jl_symbol(VarName), (jl_value_t *)ret);
       break;
     }
@@ -127,8 +127,7 @@ static jl_value_t *R_Julia_MD(SEXP Var, const char *VarName)
     {
       ret = CreateArray(jl_float64_type, jl_nfields(dims), dims);
       double *retData = (double *)jl_array_data(ret);
-      for (size_t i = 0; i < jl_array_len(ret); i++)
-        retData[i] = REAL(Var)[i];
+      memcpy(retData, REAL(Var), jl_array_len(ret) * sizeof(retData));
       jl_set_global(jl_main_module, jl_symbol(VarName), (jl_value_t *)ret);
       break;
     }


### PR DESCRIPTION
This PR contains a workaround for the problem of creating a tuple of array dimensions in when r2j is called for the vector and matrix cases. There are a few smaller optimizations that use memcpy to copy the vector from R to julia or hoist the R data pointer lookup macro. When copying a STRSXP, I use a branch with alternate loops for ASCII or Utf8 rather than branching in the loop.

The end result is a 19X speedup for j2r. If this new arrangement looks good, I can do the same thing for R_Julia_MD_NA and then simplify RDims_JuliaTuple to remove the vector case.

I tried to figure out how to use jl_apply_tuple_type in RDims_JuliaTuple, but failed.  I'm sure it can be done, though.