### PR TITLE
[WIP] representing R list as julia Vector{Any}

### DIFF
--- a/R/rjulia.R
+++ b/R/rjulia.R
@@ -28,14 +28,8 @@ isJuliaOk <- function() .Call("Julia_is_running", PACKAGE="rjulia")
 j2r <- julia_eval <- function(expression)
 {
   .julia_init_if_necessary()
-  ## Evaluate the expression and return the results of that evaluation. If it's appropriate
-  ## to provide it to the user as a vector, do so - otherwise provide it raw.
-  eval_result <- .Call("jl_eval", expression, PACKAGE="rjulia")
-  if((length(dim(eval_result)) == 1)||(length(eval_result) == 1)) {
-    as.vector(eval_result)
-  } else {
-    eval_result
-  }
+  ## Evaluate the expression and return the results of that evaluation.
+  .Call("jl_eval", expression, PACKAGE="rjulia")
 }
 
 jDo <- julia_void_eval <- function(expression)

--- a/src/Julia_R.c
+++ b/src/Julia_R.c
@@ -321,6 +321,12 @@ static SEXP Julia_R_MD(jl_value_t *Var)
     PROTECT(ans = allocArray(STRSXP, dims)); nprot++;
     for (size_t i = 0; i < len; i++)
       SET_STRING_ELT(ans, i, mkChar(jl_string_data(jl_cellref(Var, i))));
+  } else if (jl_any_type==vartype) {
+    PROTECT(ans = allocArray(VECSXP, dims)); nprot++;
+    jl_value_t **p = (jl_value_t **) jl_array_data(Var);
+    for (size_t i = 0; i < len; i++)
+      //      SET_VECTOR_ELT(ans, i, R_NilValue);
+      SET_VECTOR_ELT(ans, i, Julia_R_MD(p[i]));
   }
   UNPROTECT(nprot);
   return ans;

--- a/src/Julia_R.c
+++ b/src/Julia_R.c
@@ -322,7 +322,7 @@ static SEXP Julia_R_MD(jl_value_t *Var)
     for (size_t i = 0; i < len; i++)
       SET_STRING_ELT(ans, i, mkChar(jl_string_data(jl_cellref(Var, i))));
   } else if (jl_any_type==vartype) {
-    PROTECT(ans = allocArray(VECSXP, dims)); nprot++;
+    PROTECT(ans = allocVector(VECSXP, len)); nprot++;
     jl_value_t **p = (jl_value_t **) jl_array_data(Var);
     for (size_t i = 0; i < len; i++)
       //      SET_VECTOR_ELT(ans, i, R_NilValue);

--- a/src/Julia_R.c
+++ b/src/Julia_R.c
@@ -15,18 +15,49 @@ Copyright (C) 2014, 2015 by Yu Gong
 #include "Julia_R.h"
 #define pkgdebug
 
+
+// Translate julia eltype to R type
+SEXP juliaTypeToSEXP(jl_value_t *Var) {
+  int nprot = 0;
+  SEXP type = R_NilValue;
+  SEXP ans = R_NilValue;
+  jl_datatype_t *vartype = jl_array_eltype(Var);
+  if (vartype == jl_utf8_string_type || vartype == jl_ascii_string_type)
+    type = STRSXP;
+  else if (vartype == jl_bool_type)
+    type = LGLSXP;
+  else if (vartype == jl_any_type)
+    type = VECSXP;
+  else if (vartype == jl_float64_type || vartype == jl_float32_type || vartype == jl_int64_type || vartype == jl_uint64_type)
+    type = REALSXP;
+  else if (vartype == jl_int32_type || vartype == jl_uint32_type || vartype == jl_int16_type || vartype == jl_uint16_type || vartype == jl_int8_type || vartype == jl_uint8_type)
+    type = INTSXP;
+  int rank = jl_array_rank(Var);
+  if (rank > 1) {
+    //get Julia dims and set R array Dims
+    int ndims = jl_array_ndims(Var);
+    SEXP dims = PROTECT(allocVector(INTSXP, ndims)); nprot++;
+    int *p = INTEGER(dims);
+    for (size_t i = 0; i < ndims; i++)
+      p[i] = jl_array_dim(Var, i);
+    PROTECT(ans = allocArray(type, dims)); nprot++;
+  } else {
+    PROTECT(ans = allocVector(type, jl_array_len(Var))); nprot++;
+  }
+  UNPROTECT(nprot);
+  return(ans);
+}
+
 // Macros for julia type to r, for shorter code
 // NOTE: You must UNPROTECT at the very end !!
 
 #define jlint_to_r					\
-    PROTECT(ans = allocArray(INTSXP, dims)); nprot++;	\
     int *res = INTEGER(ans);				\
     for (size_t i = 0; i < len; i++)			\
 	res[i] = p[i]
 
 
 #define jlfloat_to_r					\
-    PROTECT(ans = allocArray(REALSXP, dims)); nprot++;	\
     double *res = REAL(ans);				\
     for (size_t i = 0; i < len; i++)			\
 	res[i] = p[i]
@@ -228,21 +259,18 @@ static SEXP Julia_R_Scalar(jl_value_t *Var)
 static SEXP Julia_R_MD(jl_value_t *Var)
 {
   SEXP ans = R_NilValue;
-  //get Julia dims and set R array Dims
+  int nprot = 0;
   int len = jl_array_len(Var);
   if (len == 0)
     return ans;
-
+  PROTECT(ans = juliaTypeToSEXP(Var)); nprot++;
+  
   jl_datatype_t *vartype=jl_array_eltype(Var);
-  int ndims = jl_array_ndims(Var), nprot = 1; // 'dims'
-  SEXP dims = PROTECT(allocVector(INTSXP, ndims));
-  for (size_t i = 0; i < ndims; i++)
-    INTEGER(dims)[i] = jl_array_dim(Var, i);
+  SEXP dims = R_NilValue;
 
   if (jl_bool_type==vartype)
   {
     char *p = (char *) jl_array_data(Var);
-    PROTECT(ans = allocArray(LGLSXP, dims)); nprot++;
     int *res = LOGICAL(ans);
     for (size_t i = 0; i < len; i++)
       res[i] = p[i];
@@ -312,20 +340,16 @@ static SEXP Julia_R_MD(jl_value_t *Var)
   // convert string array to STRSXP, but not sure it is correct ?
   else if (jl_utf8_string_type==vartype)
   {
-    PROTECT(ans = allocArray(STRSXP, dims)); nprot++;
     for (size_t i = 0; i < len; i++)
       SET_STRING_ELT(ans, i, mkCharCE(jl_string_data(jl_cellref(Var, i)), CE_UTF8));
   }
   else if (jl_ascii_string_type==vartype)
   {
-    PROTECT(ans = allocArray(STRSXP, dims)); nprot++;
     for (size_t i = 0; i < len; i++)
       SET_STRING_ELT(ans, i, mkChar(jl_string_data(jl_cellref(Var, i))));
   } else if (jl_any_type==vartype) {
-    PROTECT(ans = allocVector(VECSXP, len)); nprot++;
     jl_value_t **p = (jl_value_t **) jl_array_data(Var);
     for (size_t i = 0; i < len; i++)
-      //      SET_VECTOR_ELT(ans, i, R_NilValue);
       SET_VECTOR_ELT(ans, i, Julia_R_MD(p[i]));
   }
   UNPROTECT(nprot);

--- a/src/R_Julia.c
+++ b/src/R_Julia.c
@@ -173,6 +173,7 @@ static jl_value_t *R_Julia_MD(SEXP Var, const char *VarName)
     case VECSXP:
     {
       jl_value_t **retData = jl_array_data(ret);
+      // Does putting these pointers in this Vector{Any} require a GC write barrier?
       for (int i = 0; i < jl_array_len(ret); i++)
       {
 	retData[i] = R_Julia_MD(VECTOR_ELT(Var,i),"foo");

--- a/src/R_Julia.c
+++ b/src/R_Julia.c
@@ -134,39 +134,32 @@ static jl_value_t *R_Julia_MD(SEXP Var, const char *VarName)
    if ((LENGTH(Var))==0)
      return (jl_value_t *) jl_nothing;
 
-   jl_array_t *ret =NULL;
+   jl_array_t *ret = NewArray(Var);
    JL_GC_PUSH(&ret);
    switch (TYPEOF(Var))
    {
     case LGLSXP:
     {
-      ret = NewArray(Var);
       char *retData = (char *)jl_array_data(ret);
       int *var_p = LOGICAL(Var);
       for (size_t i = 0; i < jl_array_len(ret); i++) // Can not be memcpy because we want the implicit cast from int32 to int8
         retData[i] = var_p[i];
-      jl_set_global(jl_main_module, jl_symbol(VarName), (jl_value_t *)ret);
       break;
     };
     case INTSXP:
     {
-      ret = NewArray(Var);
       int *retData = (int *)jl_array_data(ret);
       memcpy(retData, INTEGER(Var), jl_array_len(ret) * sizeof(int));
-      jl_set_global(jl_main_module, jl_symbol(VarName), (jl_value_t *)ret);
       break;
     }
     case REALSXP:
     {
-      ret = NewArray(Var);
       double *retData = (double *)jl_array_data(ret);
       memcpy(retData, REAL(Var), jl_array_len(ret) * sizeof(double));
-      jl_set_global(jl_main_module, jl_symbol(VarName), (jl_value_t *)ret);
       break;
     }
     case STRSXP:
     {
-      ret = NewArray(Var);
       jl_value_t **retData = jl_array_data(ret);
       if (!ISASCII(Var)) {
 	for (size_t i = 0; i < jl_array_len(ret); i++)
@@ -175,60 +168,17 @@ static jl_value_t *R_Julia_MD(SEXP Var, const char *VarName)
 	for (size_t i = 0; i < jl_array_len(ret); i++)
           retData[i] = jl_cstr_to_string(CHAR(STRING_ELT(Var, i)));
       }
-      jl_set_global(jl_main_module, jl_symbol(VarName), (jl_value_t *)ret);
       break;
     }
-    /*case VECSXP:
-    {
-      char eltcmd[eltsize];
-      ret =(jl_value_t *) jl_alloc_svec(length(Var));
-      for (int i = 0; i < length(Var); i++)
-      {
-        snprintf(eltcmd, eltsize, "%selement%d", VarName, i);
-        jl_svecset((jl_value_t*)ret, i, R_Julia_MD(VECTOR_ELT(Var, i), eltcmd));
-        //clear
-        snprintf(eltcmd, eltsize, "%selement%d=0;", VarName, i);
-        jl_eval_string(eltcmd);
-      }
-      jl_set_global(jl_main_module, jl_symbol(VarName), (jl_value_t *)ret);
-      break;
-    }*/
     case VECSXP:
     {
-      char eltcmd[eltsize];
-      char evalcmd[evalsize];
-	  
-      //get VECSXP elements in julia object array
-      jl_value_t **elts;
-      JL_GC_PUSHARGS(elts,length(Var));
-      for (int i = 0; i < length(Var); i++)
+      jl_value_t **retData = jl_array_data(ret);
+      for (int i = 0; i < jl_array_len(ret); i++)
       {
-        snprintf(eltcmd, eltsize, "%selt%d", VarName, i);
-        elts[i]=R_Julia_MD(VECTOR_ELT(Var,i),eltcmd);
+	retData[i] = R_Julia_MD(VECTOR_ELT(Var,i),"foo");
       }
-	  
-      //create tuple use julia scripts, no API can create Tuple now
-      snprintf(evalcmd, evalsize, "%s","(");
-      for (size_t i = 0; i <length(Var); i++)
-      {
-       snprintf(eltcmd, eltsize, "%selt%d,", VarName, i);
-       strcat(evalcmd,eltcmd);
-      }
-      strcat(evalcmd,")");
-      ret=jl_eval_string(evalcmd);
-      jl_set_global(jl_main_module, jl_symbol(VarName), (jl_value_t *)ret);
-      
-      //clear tmp variable value
-      for (size_t i = 0; i <length(Var); i++)
-      {
-       snprintf(eltcmd, eltsize, "%selt%d=0", VarName, i);
-       jl_eval_string(eltcmd);
-      }
-	  
-      JL_GC_POP();
       break;
     }
-
     default:
     {
       ret=(jl_value_t *)jl_nothing;
@@ -244,7 +194,6 @@ static jl_value_t *R_Julia_MD(SEXP Var, const char *VarName)
 //first pass creat array then convert it to DataArray
 //second pass assign NA to element
 static jl_value_t *TransArrayToDataArray(jl_array_t *mArray, jl_array_t *mboolArray, const char *VarName)
-
 {
   char evalcmd[evalsize];
   jl_set_global(jl_main_module, jl_symbol("TransVarName"), (jl_value_t *)mArray);
@@ -518,34 +467,33 @@ static jl_value_t *R_Julia_MD_NA_DataFrame(SEXP Var, const char *VarName)
 }
 
 //Convert R Type To Julia,which not contain NA
-SEXP R_Julia(SEXP Var, SEXP VarNam)
+SEXP R_Julia(SEXP Var, SEXP VarName)
 {
-  const char *VarName = CHAR(STRING_ELT(VarNam, 0));
-  R_Julia_MD(Var, VarName);
+  jl_value_t *ret = R_Julia_MD(Var, CHAR(STRING_ELT(VarName, 0)));
+  JL_GC_PUSH(&ret);  
+  jl_set_global(jl_main_module, jl_symbol(CHAR(STRING_ELT(VarName, 0))), ret);
+  JL_GC_POP();
   return R_NilValue;
 }
 
 //Convert R Type To Julia,which contain NA
-SEXP R_Julia_NA(SEXP Var, SEXP VarNam)
+SEXP R_Julia_NA(SEXP Var, SEXP VarName)
 {
   LoadDF();
-  const char *VarName = CHAR(STRING_ELT(VarNam, 0));
-  R_Julia_MD_NA(Var, VarName);
+  R_Julia_MD_NA(Var, CHAR(STRING_ELT(VarName, 0)));
   return R_NilValue;
 }
 //Convert R factor To Julia,which contain NA
-SEXP R_Julia_NA_Factor(SEXP Var, SEXP VarNam)
+SEXP R_Julia_NA_Factor(SEXP Var, SEXP VarName)
 {
   LoadDF();
-  const char *VarName = CHAR(STRING_ELT(VarNam, 0));
-  R_Julia_MD_NA_Factor(Var, VarName);
+  R_Julia_MD_NA_Factor(Var, CHAR(STRING_ELT(VarName, 0)));
   return R_NilValue;
 }
 //Convert R data frame To Julia
-SEXP R_Julia_NA_DataFrame(SEXP Var, SEXP VarNam)
+SEXP R_Julia_NA_DataFrame(SEXP Var, SEXP VarName)
 {
   LoadDF();
-  const char *VarName = CHAR(STRING_ELT(VarNam, 0));
-  R_Julia_MD_NA_DataFrame(Var, VarName);
+  R_Julia_MD_NA_DataFrame(Var, CHAR(STRING_ELT(VarName, 0)));
   return R_NilValue;
 }

--- a/tests/unit/test_roundtrip.R
+++ b/tests/unit/test_roundtrip.R
@@ -26,7 +26,7 @@ test_roundtrip <- function() {
             lapply(
                 types,
                 function(x) {
-                    message(x)
+                    message(x, ": ", k)
                     v = as(v, x)
                     r2j(v, k)
                     checkIdentical( v, j2r(k) )
@@ -42,6 +42,7 @@ test_roundtrip <- function() {
                r2j(v, k)
                checkIdentical( v, j2r(k) )
            })
+
 }
 
 ## Repeated run r2j and j2r, can detect 'random' segfaults

--- a/tests/unit/test_roundtrip.R
+++ b/tests/unit/test_roundtrip.R
@@ -2,6 +2,7 @@
 
 library(RUnit)
 library(rjulia)
+rjulia:::.julia_init_if_necessary()
 
 ## Send data of each atomic type to julia and back again
 ##  With and without NAs
@@ -13,7 +14,9 @@ test_roundtrip <- function() {
         c = array( c(0:8), dim=c(2, 2, 2)), 
         d = c(NA_integer_, 0:4), 
         e = matrix(c(0:4, NA_integer_), ncol=2), 
-        f = array( c(0:7, NA_integer_), dim=c(2, 2, 2))
+        f = array( c(0:7, NA_integer_), dim=c(2, 2, 2)),
+        h = list( 1:5, letters ),
+        j = list( c(NA, 2:5), letters )
     )
 
     types = c("integer", "logical", "numeric", "character")

--- a/tests/unit/test_roundtrip.R
+++ b/tests/unit/test_roundtrip.R
@@ -1,3 +1,4 @@
+
 ### Test sending data from R to julia and back again
 
 library(RUnit)

--- a/tests/unit/test_roundtrip.R
+++ b/tests/unit/test_roundtrip.R
@@ -15,9 +15,7 @@ test_roundtrip <- function() {
         c = array( c(0:8), dim=c(2, 2, 2)), 
         d = c(NA_integer_, 0:4), 
         e = matrix(c(0:4, NA_integer_), ncol=2), 
-        f = array( c(0:7, NA_integer_), dim=c(2, 2, 2)),
-        h = list( 1:5, letters ),
-        j = list( c(NA, 2:5), letters )
+        f = array( c(0:7, NA_integer_), dim=c(2, 2, 2))
     )
 
     types = c("integer", "logical", "numeric", "character")
@@ -34,6 +32,16 @@ test_roundtrip <- function() {
                     checkIdentical( v, j2r(k) )
                 })
         })
+
+    lists = list(
+        h = list( 1:5, letters ),
+        j = list( c(NA, 2:5), letters )
+    )
+    mapply(names(lists), lists,
+           FUN=function(k, v) {
+               r2j(v, k)
+               checkIdentical( v, j2r(k) )
+           })
 }
 
 ## Repeated run r2j and j2r, can detect 'random' segfaults


### PR DESCRIPTION
This PR alters R_Julia_MD to return Vector{Any} when given an R list (VECSXP).  To make doing so simpler, it also moves the association the new R_Julia_MD array with a julia global symbol to the R_Julia function.  This is nice because it allows other functions to call R_Julia_MD without creating and destroying temporary global symbols (like in list or DataFrame creation).

I added tests to the roundtrip tests to check lists too. ~~These tests currently break because the j2r side of this is not yet implemented.~~

I'd be interested to know if you like this idea of moving the jl_set_global operation out of R_Julia_MD.

I have added return of Vector{Any} as VECSXP.

In a bigger change, I have centralized all of the R array creation to one function and handled the difference between return vectors and arrays there rather than stripping the dims off of 1D arrays later in R.

There are probably a few special types that are not doing the right thing in my code. For example, I just handle int64 as REALSXP rather than trying to see if it will fit in INTSXP (int32).