### PR TITLE
[wip] String not ascii for 05

### DIFF
--- a/src/Julia_R.c
+++ b/src/Julia_R.c
@@ -19,7 +19,7 @@ Copyright (C) 2014, 2015 by Yu Gong
 // Translate julia eltype to R type
 SEXP juliaArrayToSEXP(jl_value_t *Var) {
   int nprot = 0;
-  SEXP type = R_NilValue;
+  SEXPTYPE type = R_NilValue;
   SEXP ans = R_NilValue;
   jl_datatype_t *vartype = jl_array_eltype(Var);
   if (vartype == jl_utf8_string_type || vartype == jl_ascii_string_type)

--- a/src/Julia_R.c
+++ b/src/Julia_R.c
@@ -19,7 +19,7 @@ Copyright (C) 2014, 2015 by Yu Gong
 // Translate julia eltype to R type
 SEXP juliaArrayToSEXP(jl_value_t *Var) {
   int nprot = 0;
-  SEXPTYPE type = R_NilValue;
+  SEXPTYPE type;
   SEXP ans = R_NilValue;
   jl_datatype_t *vartype = jl_array_eltype(Var);
   if (vartype == jl_utf8_string_type || vartype == jl_ascii_string_type)

--- a/src/R_Julia.c
+++ b/src/R_Julia.c
@@ -145,8 +145,7 @@ static jl_value_t *R_Julia_MD(SEXP Var, const char *VarName)
     }
     default:
     {
-      ret=(jl_value_t *)jl_nothing;
-      break;
+      return (jl_value_t *)jl_nothing;
     }
    }
   JL_GC_POP();


### PR DESCRIPTION
This should be what is required to switch to String from ASCIIString and UTF8String for julia 0.5. There was one fix for an apparent change in the API for symbols. There are also a few changes in snprintf formatting codes to fix some compile warnings.

This is not backwards compatible. The 0.4 to 0.5 changes are mixed in throughout the code, so I'm not sure how one would use IFDEF blocks to handle 0.4 and 0.5 at the same time.

I believe there is some trouble with libjulia there is a symbol (not used by rjulia) that cannot be found.  I think this is a problem with julia itself, but I don't fully understand the issue.